### PR TITLE
feat: change triggerWorkflow to accept an optional ref parameter, default to base

### DIFF
--- a/src/upsertProject.ts
+++ b/src/upsertProject.ts
@@ -164,13 +164,13 @@ export const getProjectsV2 = async (context: Context, release: string) => {
 	return project;
 };
 
-const triggerWorkflow = async (context: Context, base = 'master') =>
+const triggerWorkflow = async (context: Context, base = 'master', ref = base) =>
 	context.octokit.actions.createWorkflowDispatch({
 		...context.repo(),
+		ref,
 		inputs: {
 			'name': 'patch',
 			'base-ref': base,
 		},
-		ref: 'refs/heads/develop',
 		workflow_id: 'new-release.yml',
 	});


### PR DESCRIPTION
This change makes it so that the file used to trigger the new release workflow comes from the same ref used as the base for the new release.

The ref used to read the workflow file [also influences caching](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache) during the workflow run

It's added as an optional parameter to the function to allow the caller to force the workflow file to come from a different ref.

[As per the docs](https://docs.github.com/en/rest/actions/workflows?apiVersion=2026-03-10#create-a-workflow-dispatch-event) we don't need to pass a fully qualified ref path to the `ref` parameter, just the branch or tag name