### PR TITLE
fix: stop labeling bots as community contributors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # The ID of your GitHub App
 APP_ID=
+
+# Organization considered "internal"; PR authors not in this org get the community label (default: RocketChat)
+# INTERNAL_ORG=RocketChat
+
+# Extra comma-separated logins never labeled community (bots already excluded via [bot] suffix)
+# COMMUNITY_LABEL_EXCLUDED_EXTRA=some-user,another-user
 WEBHOOK_SECRET=development
 
 # Use `trace` to get verbose logging or `info` to show less

--- a/src/handleQALabels.ts
+++ b/src/handleQALabels.ts
@@ -55,10 +55,7 @@ export const applyLabels = async (
 		const { originalLabels } = result;
 		let newLabels = result.newLabels;
 		const authorLogin = pullRequest.user?.login;
-		if (
-			authorLogin &&
-			!COMMUNITY_LABEL_EXCLUDED_AUTHORS.includes(authorLogin)
-		) {
+		if (authorLogin && !COMMUNITY_LABEL_EXCLUDED_AUTHORS.includes(authorLogin)) {
 			const external = await isExternalContributor(context.octokit, authorLogin);
 			if (external && !newLabels.includes('community')) {
 				newLabels = [...newLabels, 'community'];

--- a/src/handleQALabels.ts
+++ b/src/handleQALabels.ts
@@ -3,9 +3,15 @@ import { runQAChecks } from './qaChecks';
 import { handleMessage } from './handleMessage';
 import { isExternalContributor } from './isExternalContributor';
 
-const { GITHUB_LOGIN = 'dionisio-bot[bot]' } = process.env;
+const { GITHUB_LOGIN = 'dionisio-bot[bot]', COMMUNITY_LABEL_EXCLUDED_EXTRA = '' } = process.env;
 
-const COMMUNITY_LABEL_EXCLUDED_AUTHORS = [GITHUB_LOGIN, 'github-copilot[bot]'];
+const COMMUNITY_LABEL_EXCLUDED_AUTHORS = [
+	GITHUB_LOGIN,
+	'github-copilot[bot]',
+	...COMMUNITY_LABEL_EXCLUDED_EXTRA.split(',')
+		.map((login) => login.trim())
+		.filter(Boolean),
+];
 
 export const applyLabels = async (
 	pullRequest: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { consoleProps } from './createPullRequest';
 import { handleRebase } from './handleRebase';
 import { handleJira, isJiraTaskKey } from './handleJira';
 import { runQAChecks, formatCheckRunOutput, CHECK_RUN_NAME, type PullRequestForQA } from './qaChecks';
+import { isExternalContributor } from './isExternalContributor';
 
 export = (app: Probot) => {
 	app.log.useLevelLabels = false;
@@ -94,11 +95,7 @@ export = (app: Probot) => {
 
 		const [, command, args] = comment.body.match(matcher) || [];
 
-		const orgs = await context.octokit.orgs.listForUser({
-			username: comment.user.login,
-		});
-
-		if (!orgs.data.some(({ login }) => login === 'RocketChat')) {
+		if (await isExternalContributor(context.octokit, comment.user.login)) {
 			return;
 		}
 

--- a/src/isExternalContributor.ts
+++ b/src/isExternalContributor.ts
@@ -10,9 +10,14 @@ export const isExternalContributor = async (
 	if (!username) {
 		return false;
 	}
+	// bots are never community contributors
+	if (username.endsWith('[bot]')) {
+		return false;
+	}
 	try {
-		const { data: orgs } = await octokit.orgs.listForUser({ username });
-		return !orgs.some(({ login }) => login === org);
+		// checkMembershipForUser sees private memberships too; listForUser only returns public ones
+		await octokit.orgs.checkMembershipForUser({ org, username });
+		return false;
 	} catch {
 		return true;
 	}


### PR DESCRIPTION
## Problem
Bots (dependabot, copilot, even dionisio itself) were getting the `community` label.

## Root cause
`isExternalContributor` used `octokit.orgs.listForUser`, which returns **only public** org memberships. Bots and users with private membership are absent from that list → flagged external → labeled `community`.

## Fix
- Skip any login ending in `[bot]` — bots are never community contributors.
- Use `checkMembershipForUser` (sees private memberships) instead of `listForUser`.
- Reuse `isExternalContributor` for the `issue_comment` command gate in `index.ts` (was duplicating the same public-only bug; now also honors `INTERNAL_ORG` env instead of hardcoded `RocketChat`).

## Note
Bots can now pass the command gate (`/bark` etc.) — previously blocked by the public-list check. Low risk; flag if bots should stay explicitly blocked there.