### PR TITLE
fix: create Task under Epic parent, not Sub-task

### DIFF
--- a/src/handleJira.ts
+++ b/src/handleJira.ts
@@ -81,6 +81,13 @@ async function projectHasVersion(jiraBaseUrl: string, jiraApiToken: string, proj
 	return Array.isArray(versions) && versions.some((v) => v.name === versionName);
 }
 
+async function getIssueType(jiraBaseUrl: string, jiraApiToken: string, issueKey: string): Promise<string | undefined> {
+	const res = await jiraFetch(jiraBaseUrl, jiraApiToken, `/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=issuetype`);
+	if (!res.ok) return undefined;
+	const issue = (await res.json()) as { fields?: { issuetype?: { name?: string } } };
+	return issue.fields?.issuetype?.name;
+}
+
 function buildDescriptionContent(usePlainText: boolean, pr: HandleJiraArg['pr'], requestedBy: string): AdfBlock[] {
 	const rawBody = pr.body?.trim() || 'no description';
 	const descriptionBlock = usePlainText
@@ -101,8 +108,11 @@ export const handleJira = async ({ context, boardName, parentTaskKey, pr, reques
 	const jiraBaseUrl = getEnv('JIRA_BASE_URL').replace(/\/$/, '');
 	const jiraApiToken = getEnv('JIRA_API_TOKEN');
 	const hasCommunityLabel = pr.labels.some((label) => label.toLowerCase() === 'community');
-	const isSubtask = Boolean(parentTaskKey);
 	const projectKey = parentTaskKey ? parentTaskKey.replace(/-\d+$/, '') : boardName;
+
+	// Epic parent → child is a Task; Task parent → child is a Sub-task.
+	const parentIsEpic = parentTaskKey ? (await getIssueType(jiraBaseUrl, jiraApiToken, parentTaskKey))?.toLowerCase() === 'epic' : false;
+	const isSubtask = Boolean(parentTaskKey) && !parentIsEpic;
 
 	const milestoneName = pr.milestone?.trim();
 	let useFixVersions = Boolean(milestoneName);
@@ -119,7 +129,7 @@ export const handleJira = async ({ context, boardName, parentTaskKey, pr, reques
 	const buildPayload = (usePlainTextDescription: boolean) => ({
 		fields: {
 			project: { key: projectKey },
-			...(isSubtask ? { parent: { key: parentTaskKey } } : {}),
+			...(parentTaskKey ? { parent: { key: parentTaskKey } } : {}),
 			summary: `[PR #${pr.number}] ${pr.title}`,
 			issuetype: { name: isSubtask ? 'Sub-task' : 'Task' },
 			...(hasCommunityLabel ? { labels: ['community'] } : {}),

--- a/src/handleQALabels.ts
+++ b/src/handleQALabels.ts
@@ -49,10 +49,7 @@ export const applyLabels = async (
 		const { originalLabels } = result;
 		let newLabels = result.newLabels;
 		const authorLogin = pullRequest.user?.login;
-		if (
-			authorLogin &&
-			!COMMUNITY_LABEL_EXCLUDED_AUTHORS.includes(authorLogin)
-		) {
+		if (authorLogin && !COMMUNITY_LABEL_EXCLUDED_AUTHORS.includes(authorLogin)) {
 			const external = await isExternalContributor(context.octokit, authorLogin);
 			if (external && !newLabels.includes('community')) {
 				newLabels = [...newLabels, 'community'];


### PR DESCRIPTION
## Problem
Jira issue creation always used `Sub-task` whenever a parent key was passed. Epics can't have sub-tasks as direct children, so passing an Epic key produced the wrong hierarchy.

## Fix
Look up the parent's issue type before choosing the child type:
- **Epic** parent → child is a **Task**, linked to the Epic
- **Task** parent → child is a **Sub-task**

Parent link (`parent: { key }`) now kept in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)