### PR TITLE
feat: enforce changeset bumps against milestone

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -83,7 +83,7 @@ default_permissions:
 
   # Pull requests and related comments, assignees, labels, milestones, and merges.
   # https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests
-  pull_requests: read
+  pull_requests: write
 
   # Manage the post-receive hooks for a repository.
   # https://developer.github.com/v3/apps/permissions/#permission-on-repository-hooks

--- a/src/checkChangesets.ts
+++ b/src/checkChangesets.ts
@@ -25,6 +25,9 @@ export const maxBumpForMilestone = (milestone?: string): Bump | null => {
 	return 'major';
 };
 
+/** Conventional-commit breaking marker: `feat!: ...` or `feat(scope)!: ...` */
+export const titleIndicatesBreaking = (title?: string): boolean => /^\w+(\([^)]*\))?!:/.test(title ?? '');
+
 export const parseChangesetBumps = (content: string): Bump[] => {
 	const [, frontmatter] = content.match(/^---\r?\n([\s\S]*?)\r?\n---/) ?? [];
 	if (!frontmatter) {
@@ -76,20 +79,48 @@ const getChangesetFiles = async (
 	);
 };
 
-const formatReviewBody = (milestone: string, maxBump: Bump, invalid: { filename: string; invalid: Bump[] }[]): string =>
-	[
-		`### Changeset x Milestone mismatch`,
-		'',
-		`The milestone \`${milestone}\` only allows \`${maxBump}\` (or lower) changesets, but:`,
-		'',
-		...invalid.map(({ filename, invalid: bumps }) => `- \`${filename}\` declares \`${bumps.join('`, `')}\``),
-		'',
-		`Please adjust the changeset bump or the milestone.`,
-	].join('\n');
+export const findChangesetProblems = (
+	files: { filename: string; bumps: Bump[] }[],
+	milestone: string | undefined,
+	title: string | undefined,
+): string[] => {
+	const problems: string[] = [];
+
+	const maxBump = maxBumpForMilestone(milestone);
+	const invalid = maxBump && maxBump !== 'major' ? findInvalidBumps(files, maxBump) : [];
+	if (invalid.length > 0) {
+		problems.push(
+			[
+				`The milestone \`${milestone}\` only allows \`${maxBump}\` (or lower) changesets, but:`,
+				'',
+				...invalid.map(({ filename, invalid: bumps }) => `- \`${filename}\` declares \`${bumps.join('`, `')}\``),
+			].join('\n'),
+		);
+	}
+
+	const hasMajor = files.some(({ bumps }) => bumps.includes('major'));
+	const breakingTitle = titleIndicatesBreaking(title);
+	if (breakingTitle && !hasMajor) {
+		problems.push('The PR title indicates a breaking change (`!`), but no changeset declares a `major` bump — at least one is required.');
+	}
+	if (!breakingTitle && hasMajor) {
+		problems.push(
+			'A changeset declares a `major` bump, but the PR title does not indicate a breaking change (use `type!: ...` or `type(scope)!: ...`).',
+		);
+	}
+
+	return problems;
+};
+
+const formatReviewBody = (problems: string[]): string =>
+	[`### Changeset mismatch`, '', ...problems.flatMap((problem) => [problem, '']), `Please align the PR title, milestone and changesets.`].join(
+		'\n',
+	);
 
 /**
- * Requests changes when a changeset declares a bump higher than the milestone allows,
- * and dismisses that review once the changesets (or milestone) are fixed.
+ * Requests changes when the PR title, milestone and changesets disagree about
+ * the release bump (breaking change or bump higher than the milestone allows),
+ * and dismisses that review once they are aligned.
  */
 export const enforceChangesetMilestone = async ({
 	octokit,
@@ -102,32 +133,31 @@ export const enforceChangesetMilestone = async ({
 	repo: string;
 	pr: {
 		number: number;
+		title?: string;
 		milestone?: string;
 		head: { owner: string; repo: string; sha: string };
 	};
 }): Promise<void> => {
-	const maxBump = maxBumpForMilestone(pr.milestone);
-
-	const invalid =
-		maxBump && maxBump !== 'major' ? findInvalidBumps(await getChangesetFiles(octokit, owner, repo, pr.number, pr.head), maxBump) : [];
+	const files = await getChangesetFiles(octokit, owner, repo, pr.number, pr.head);
+	const problems = findChangesetProblems(files, pr.milestone, pr.title);
 
 	const reviews = await octokit.pulls.listReviews({ owner, repo, pull_number: pr.number });
 	const botReview = reviews.data.find((review) => review.user?.login === GITHUB_LOGIN && review.state === 'CHANGES_REQUESTED');
 
-	if (invalid.length === 0) {
+	if (problems.length === 0) {
 		if (botReview) {
 			await octokit.pulls.dismissReview({
 				owner,
 				repo,
 				pull_number: pr.number,
 				review_id: botReview.id,
-				message: 'Changesets now match the milestone',
+				message: 'Changesets now match the title and milestone',
 			});
 		}
 		return;
 	}
 
-	const body = formatReviewBody(pr.milestone as string, maxBump as Bump, invalid);
+	const body = formatReviewBody(problems);
 
 	if (botReview?.body === body) {
 		return;

--- a/src/checkChangesets.ts
+++ b/src/checkChangesets.ts
@@ -1,0 +1,153 @@
+import type { Context } from 'probot';
+
+const { GITHUB_LOGIN = 'dionisio-bot[bot]' } = process.env;
+
+export type Bump = 'patch' | 'minor' | 'major';
+
+const BUMP_RANK: Record<Bump, number> = { patch: 0, minor: 1, major: 2 };
+
+/**
+ * Milestone x.y.z with z > 0 only allows patch bumps;
+ * x.y.0 allows up to minor; x.0.0 allows major.
+ * Milestones without a version (e.g. "Backlog") impose no restriction.
+ */
+export const maxBumpForMilestone = (milestone?: string): Bump | null => {
+	const match = milestone?.match(/(\d+)\.(\d+)(?:\.(\d+))?/);
+	if (!match) {
+		return null;
+	}
+	if (parseInt(match[3] ?? '0') > 0) {
+		return 'patch';
+	}
+	if (parseInt(match[2]) > 0) {
+		return 'minor';
+	}
+	return 'major';
+};
+
+export const parseChangesetBumps = (content: string): Bump[] => {
+	const [, frontmatter] = content.match(/^---\r?\n([\s\S]*?)\r?\n---/) ?? [];
+	if (!frontmatter) {
+		return [];
+	}
+	return [...frontmatter.matchAll(/:\s*['"]?(patch|minor|major)['"]?\s*$/gm)].map((m) => m[1] as Bump);
+};
+
+export const findInvalidBumps = (files: { filename: string; bumps: Bump[] }[], maxBump: Bump): { filename: string; invalid: Bump[] }[] =>
+	files
+		.map(({ filename, bumps }) => ({
+			filename,
+			invalid: bumps.filter((bump) => BUMP_RANK[bump] > BUMP_RANK[maxBump]),
+		}))
+		.filter(({ invalid }) => invalid.length > 0);
+
+const isChangesetFile = (filename: string) => /^\.changeset\/[^/]+\.md$/.test(filename) && filename !== '.changeset/README.md';
+
+const getChangesetFiles = async (
+	octokit: Context['octokit'],
+	owner: string,
+	repo: string,
+	prNumber: number,
+	head: { owner: string; repo: string; sha: string },
+): Promise<{ filename: string; bumps: Bump[] }[]> => {
+	const files = await octokit.paginate(octokit.pulls.listFiles, {
+		owner,
+		repo,
+		pull_number: prNumber,
+		per_page: 100,
+	});
+
+	const changesets = files.filter((file) => isChangesetFile(file.filename) && file.status !== 'removed');
+
+	return Promise.all(
+		changesets.map(async ({ filename }) => {
+			const { data } = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+				owner: head.owner,
+				repo: head.repo,
+				path: filename,
+				ref: head.sha,
+				headers: {
+					'Accept': 'application/vnd.github.raw+json',
+					'X-GitHub-Api-Version': '2022-11-28',
+				},
+			});
+			return { filename, bumps: typeof data === 'string' ? parseChangesetBumps(data) : [] };
+		}),
+	);
+};
+
+const formatReviewBody = (milestone: string, maxBump: Bump, invalid: { filename: string; invalid: Bump[] }[]): string =>
+	[
+		`### Changeset x Milestone mismatch`,
+		'',
+		`The milestone \`${milestone}\` only allows \`${maxBump}\` (or lower) changesets, but:`,
+		'',
+		...invalid.map(({ filename, invalid: bumps }) => `- \`${filename}\` declares \`${bumps.join('`, `')}\``),
+		'',
+		`Please adjust the changeset bump or the milestone.`,
+	].join('\n');
+
+/**
+ * Requests changes when a changeset declares a bump higher than the milestone allows,
+ * and dismisses that review once the changesets (or milestone) are fixed.
+ */
+export const enforceChangesetMilestone = async ({
+	octokit,
+	owner,
+	repo,
+	pr,
+}: {
+	octokit: Context['octokit'];
+	owner: string;
+	repo: string;
+	pr: {
+		number: number;
+		milestone?: string;
+		head: { owner: string; repo: string; sha: string };
+	};
+}): Promise<void> => {
+	const maxBump = maxBumpForMilestone(pr.milestone);
+
+	const invalid =
+		maxBump && maxBump !== 'major' ? findInvalidBumps(await getChangesetFiles(octokit, owner, repo, pr.number, pr.head), maxBump) : [];
+
+	const reviews = await octokit.pulls.listReviews({ owner, repo, pull_number: pr.number });
+	const botReview = reviews.data.find((review) => review.user?.login === GITHUB_LOGIN && review.state === 'CHANGES_REQUESTED');
+
+	if (invalid.length === 0) {
+		if (botReview) {
+			await octokit.pulls.dismissReview({
+				owner,
+				repo,
+				pull_number: pr.number,
+				review_id: botReview.id,
+				message: 'Changesets now match the milestone',
+			});
+		}
+		return;
+	}
+
+	const body = formatReviewBody(pr.milestone as string, maxBump as Bump, invalid);
+
+	if (botReview?.body === body) {
+		return;
+	}
+
+	await octokit.pulls.createReview({
+		owner,
+		repo,
+		pull_number: pr.number,
+		event: 'REQUEST_CHANGES',
+		body,
+	});
+
+	if (botReview) {
+		await octokit.pulls.dismissReview({
+			owner,
+			repo,
+			pull_number: pr.number,
+			review_id: botReview.id,
+			message: 'Superseded by an updated review',
+		});
+	}
+};

--- a/src/checkChangesets.ts
+++ b/src/checkChangesets.ts
@@ -113,9 +113,12 @@ export const findChangesetProblems = (
 };
 
 const formatReviewBody = (problems: string[]): string =>
-	[`### Changeset mismatch`, '', ...problems.flatMap((problem) => [problem, '']), `Please align the PR title, milestone and changesets.`].join(
-		'\n',
-	);
+	[
+		`### Changeset mismatch`,
+		'',
+		...problems.flatMap((problem) => [problem, '']),
+		`Please align the PR title, milestone and changesets.`,
+	].join('\n');
 
 /**
  * Requests changes when the PR title, milestone and changesets disagree about

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { consoleProps } from './createPullRequest';
 import { handleRebase } from './handleRebase';
 import { handleJira, isJiraTaskKey } from './handleJira';
 import { runQAChecks, formatCheckRunOutput, CHECK_RUN_NAME, type PullRequestForQA } from './qaChecks';
+import { enforceChangesetMilestone } from './checkChangesets';
 import { isExternalContributor } from './isExternalContributor';
 
 export = (app: Probot) => {
@@ -448,6 +449,25 @@ export = (app: Probot) => {
 		]);
 
 		const hasReviews = reviews.data.some((r) => r.user?.type !== 'Bot');
+
+		try {
+			await enforceChangesetMilestone({
+				octokit,
+				owner: baseOwner,
+				repo: baseRepo,
+				pr: {
+					number: prNumber,
+					milestone: fullPr.data.milestone?.title,
+					head: {
+						owner: fullPr.data.head.repo?.owner.login ?? baseOwner,
+						repo: fullPr.data.head.repo?.name ?? baseRepo,
+						sha: fullPr.data.head.sha,
+					},
+				},
+			});
+		} catch (error) {
+			console.log('enforceChangesetMilestone->', error);
+		}
 
 		const prForQA: PullRequestForQA = {
 			mergeable: fullPr.data.mergeable ?? undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,6 +457,7 @@ export = (app: Probot) => {
 				repo: baseRepo,
 				pr: {
 					number: prNumber,
+					title: fullPr.data.title,
 					milestone: fullPr.data.milestone?.title,
 					head: {
 						owner: fullPr.data.head.repo?.owner.login ?? baseOwner,

--- a/test/checkChangesets.test.ts
+++ b/test/checkChangesets.test.ts
@@ -1,0 +1,73 @@
+import { maxBumpForMilestone, parseChangesetBumps, findInvalidBumps } from '../src/checkChangesets';
+
+describe('maxBumpForMilestone', () => {
+	test('patch milestone only allows patch', () => {
+		expect(maxBumpForMilestone('7.10.1')).toBe('patch');
+		expect(maxBumpForMilestone('6.5.11')).toBe('patch');
+	});
+
+	test('minor milestone allows up to minor', () => {
+		expect(maxBumpForMilestone('7.10.0')).toBe('minor');
+		expect(maxBumpForMilestone('7.10')).toBe('minor');
+	});
+
+	test('major milestone allows up to major', () => {
+		expect(maxBumpForMilestone('8.0.0')).toBe('major');
+		expect(maxBumpForMilestone('8.0')).toBe('major');
+	});
+
+	test('non-version milestones impose no restriction', () => {
+		expect(maxBumpForMilestone('Backlog')).toBeNull();
+		expect(maxBumpForMilestone(undefined)).toBeNull();
+		expect(maxBumpForMilestone('')).toBeNull();
+	});
+});
+
+describe('parseChangesetBumps', () => {
+	test('parses single package', () => {
+		expect(parseChangesetBumps("---\n'@rocket.chat/meteor': patch\n---\n\nFix something\n")).toEqual(['patch']);
+	});
+
+	test('parses multiple packages and quote styles', () => {
+		const content = ['---', "'@rocket.chat/meteor': minor", '"@rocket.chat/ui-client": patch', '@rocket.chat/core: major', '---', '', 'desc'].join(
+			'\n',
+		);
+		expect(parseChangesetBumps(content)).toEqual(['minor', 'patch', 'major']);
+	});
+
+	test('handles CRLF', () => {
+		expect(parseChangesetBumps("---\r\n'@rocket.chat/meteor': minor\r\n---\r\ndesc")).toEqual(['minor']);
+	});
+
+	test('no frontmatter means no bumps', () => {
+		expect(parseChangesetBumps('just a description')).toEqual([]);
+		expect(parseChangesetBumps('')).toEqual([]);
+	});
+
+	test('ignores bump-like words outside frontmatter', () => {
+		expect(parseChangesetBumps("---\n'@rocket.chat/meteor': patch\n---\n\nthis is a major: change")).toEqual(['patch']);
+	});
+});
+
+describe('findInvalidBumps', () => {
+	const files = [
+		{ filename: '.changeset/one.md', bumps: ['patch'] as const },
+		{ filename: '.changeset/two.md', bumps: ['minor', 'patch'] as const },
+		{ filename: '.changeset/three.md', bumps: ['major'] as const },
+	].map((f) => ({ ...f, bumps: [...f.bumps] }));
+
+	test('patch milestone flags minor and major changesets', () => {
+		expect(findInvalidBumps(files, 'patch')).toEqual([
+			{ filename: '.changeset/two.md', invalid: ['minor'] },
+			{ filename: '.changeset/three.md', invalid: ['major'] },
+		]);
+	});
+
+	test('minor milestone flags only major changesets', () => {
+		expect(findInvalidBumps(files, 'minor')).toEqual([{ filename: '.changeset/three.md', invalid: ['major'] }]);
+	});
+
+	test('major milestone flags nothing', () => {
+		expect(findInvalidBumps(files, 'major')).toEqual([]);
+	});
+});

--- a/test/checkChangesets.test.ts
+++ b/test/checkChangesets.test.ts
@@ -1,4 +1,5 @@
-import { maxBumpForMilestone, parseChangesetBumps, findInvalidBumps } from '../src/checkChangesets';
+import { maxBumpForMilestone, parseChangesetBumps, findInvalidBumps, titleIndicatesBreaking, findChangesetProblems } from '../src/checkChangesets';
+import type { Bump } from '../src/checkChangesets';
 
 describe('maxBumpForMilestone', () => {
 	test('patch milestone only allows patch', () => {
@@ -69,5 +70,42 @@ describe('findInvalidBumps', () => {
 
 	test('major milestone flags nothing', () => {
 		expect(findInvalidBumps(files, 'major')).toEqual([]);
+	});
+});
+
+describe('titleIndicatesBreaking', () => {
+	test('detects conventional-commit breaking marker', () => {
+		expect(titleIndicatesBreaking('feat!: drop legacy API')).toBe(true);
+		expect(titleIndicatesBreaking('feat(core)!: drop legacy API')).toBe(true);
+	});
+
+	test('regular titles are not breaking', () => {
+		expect(titleIndicatesBreaking('feat: add thing')).toBe(false);
+		expect(titleIndicatesBreaking('fix(core): oops')).toBe(false);
+		expect(titleIndicatesBreaking('Wow! great PR')).toBe(false);
+		expect(titleIndicatesBreaking(undefined)).toBe(false);
+	});
+});
+
+describe('findChangesetProblems', () => {
+	const major = [{ filename: '.changeset/big.md', bumps: ['major'] as Bump[] }];
+	const patch = [{ filename: '.changeset/small.md', bumps: ['patch'] as Bump[] }];
+
+	test('breaking title requires at least one major changeset', () => {
+		expect(findChangesetProblems(patch, '8.0.0', 'feat!: breaking')).toHaveLength(1);
+		expect(findChangesetProblems([], '8.0.0', 'feat!: breaking')).toHaveLength(1);
+		expect(findChangesetProblems(major, '8.0.0', 'feat!: breaking')).toEqual([]);
+	});
+
+	test('major changeset requires breaking title', () => {
+		expect(findChangesetProblems(major, '8.0.0', 'feat: not breaking')).toHaveLength(1);
+	});
+
+	test('milestone and title problems are both reported', () => {
+		expect(findChangesetProblems(major, '7.10.1', 'feat: not breaking')).toHaveLength(2);
+	});
+
+	test('aligned patch PR has no problems', () => {
+		expect(findChangesetProblems(patch, '7.10.1', 'fix: something')).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What

Validates changeset bump values against the PR milestone and enforces the result as a bot review:

- Milestone `x.y.z` with `z > 0` (patch release) → only `patch` changesets allowed
- Milestone `x.y.0` / `x.y` → up to `minor`
- Milestone `x.0.0` → no restriction
- No milestone or non-version milestone (e.g. "Backlog") → no restriction

When a changeset declares a bump higher than the milestone allows, the bot creates a **request changes** review listing the offending files. Once the changesets (or the milestone) are fixed, the review is dismissed automatically. If the set of invalid files changes, the review is superseded (new review, old one dismissed); identical state does not create duplicates.

## How

- New `src/checkChangesets.ts`: pure helpers (`maxBumpForMilestone`, `parseChangesetBumps`, `findInvalidBumps`) plus the `enforceChangesetMilestone` orchestration
- Hooked into `runDionisioQACheckForRef`, so it runs on the same events as the QA check (opened/synchronize/edited/labeled/milestoned/check_suite)
- Reads `.changeset/*.md` from the PR head (fork-aware), skipping `README.md` and removed files
- `app.yml`: `pull_requests` permission bumped to `write` (required for creating/dismissing reviews — the installed app permission on GitHub needs the same update)

## Tests

`test/checkChangesets.test.ts` covers milestone parsing, changeset frontmatter parsing (quote styles, CRLF, missing frontmatter) and invalid-bump detection.